### PR TITLE
Fix pushing arguments to stack

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,14 @@ use libc::{pid_t, ptrace, PTRACE_ATTACH, PTRACE_CONT, PTRACE_DETACH};
 use std::{mem, process::Child};
 use thiserror::Error;
 
+fn usize_arr_to_u8(data: &[usize]) -> Vec<u8> {
+    let mut arr: Vec<u8> = Vec::new();
+    for p in data {
+        arr.extend_from_slice(&p.to_le_bytes());
+    }
+    return arr;
+}
+
 #[derive(Debug, Error)]
 pub enum TraceError {
     #[error("Ptrace error: `{0}`")]
@@ -222,9 +230,7 @@ where
                 current_registers.stack_pointer() - (stack_arguments.len() * size_of::<usize>()),
             );
 
-            self.write_memory(current_registers.stack_pointer(), unsafe {
-                std::mem::transmute(stack_arguments)
-            })?;
+            self.write_memory(current_registers.stack_pointer(), usize_arr_to_u8(stack_arguments).as_slice())?;
         };
 
         // set registers cached_registers
@@ -310,9 +316,7 @@ where
                 current_registers.stack_pointer() - (stack_arguments.len() * size_of::<usize>()),
             );
 
-            self.write_memory(current_registers.stack_pointer(), unsafe {
-                std::mem::transmute(stack_arguments)
-            })?;
+            self.write_memory(current_registers.stack_pointer(), usize_arr_to_u8(stack_arguments).as_slice())?;
         };
 
         // set registers cached_registers
@@ -366,9 +370,7 @@ where
         current_registers.set_stack_pointer(
             current_registers.stack_pointer() - (param_count * size_of::<usize>()),
         );
-        self.write_memory(current_registers.stack_pointer(), unsafe {
-            std::mem::transmute(parameters)
-        })?;
+        self.write_memory(current_registers.stack_pointer(), usize_arr_to_u8(parameters).as_slice())?;
 
         // return address is bottom of stack!
         current_registers.set_stack_pointer(current_registers.stack_pointer() - size_of::<usize>());
@@ -445,9 +447,7 @@ where
             current_registers.set_stack_pointer(
                 current_registers.stack_pointer() - (stack_arguments.len() * size_of::<usize>()),
             );
-            self.write_memory(current_registers.stack_pointer(), unsafe {
-                std::mem::transmute(stack_arguments)
-            })?;
+            self.write_memory(current_registers.stack_pointer(), usize_arr_to_u8(stack_arguments).as_slice())?;
         };
 
         // return address is bottom of stack!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,6 +212,7 @@ where
         );
 
         let cached_registers = current_registers.clone();
+        current_registers.set_stack_pointer(current_registers.stack_pointer() & !0xfusize);
         for (i, param) in parameters[..std::cmp::min(parameters.len(), REGISTER_ARGUMENTS)]
             .iter()
             .enumerate()
@@ -227,7 +228,7 @@ where
 
             // adjust stack pointer
             current_registers.set_stack_pointer(
-                current_registers.stack_pointer() - (stack_arguments.len() * size_of::<usize>()),
+                current_registers.stack_pointer() - (((stack_arguments.len() + 1) & !1usize) * size_of::<usize>()),
             );
 
             self.write_memory(current_registers.stack_pointer(), usize_arr_to_u8(stack_arguments).as_slice())?;
@@ -298,6 +299,7 @@ where
         );
 
         let cached_registers = current_registers.clone();
+        current_registers.set_stack_pointer(current_registers.stack_pointer() & !0xfusize);
         for (i, param) in parameters[..std::cmp::min(parameters.len(), REGISTER_ARGUMENTS)]
             .iter()
             .enumerate()
@@ -313,7 +315,7 @@ where
 
             // adjust stack pointer
             current_registers.set_stack_pointer(
-                current_registers.stack_pointer() - (stack_arguments.len() * size_of::<usize>()),
+                current_registers.stack_pointer() - (((stack_arguments.len() + 3) & !3usize) * size_of::<usize>()),
             );
 
             self.write_memory(current_registers.stack_pointer(), usize_arr_to_u8(stack_arguments).as_slice())?;
@@ -363,14 +365,17 @@ where
 
         let cached_registers = current_registers.clone();
         let param_count = parameters.len();
+        current_registers.set_stack_pointer(current_registers.stack_pointer() & !0xfusize);
 
         tracing::trace!("Function parameters: {:?}", parameters);
 
-        // adjust stack pointer
-        current_registers.set_stack_pointer(
-            current_registers.stack_pointer() - (param_count * size_of::<usize>()),
-        );
-        self.write_memory(current_registers.stack_pointer(), usize_arr_to_u8(parameters).as_slice())?;
+        if param_count > 0 {
+            // adjust stack pointer
+            current_registers.set_stack_pointer(
+                current_registers.stack_pointer() - (((param_count + 3) & !3usize) * size_of::<usize>()),
+            );
+            self.write_memory(current_registers.stack_pointer(), usize_arr_to_u8(parameters).as_slice())?;
+        }
 
         // return address is bottom of stack!
         current_registers.set_stack_pointer(current_registers.stack_pointer() - size_of::<usize>());
@@ -418,6 +423,7 @@ where
 
         let cached_registers = current_registers.clone();
         let param_count = parameters.len();
+        current_registers.set_stack_pointer(current_registers.stack_pointer() & !0xfusize);
 
         // You gotta a better idea???????
         if param_count > 0 {
@@ -445,7 +451,7 @@ where
 
             // adjust stack pointer
             current_registers.set_stack_pointer(
-                current_registers.stack_pointer() - (stack_arguments.len() * size_of::<usize>()),
+                current_registers.stack_pointer() - (((stack_arguments.len() + 1) & !1usize) * size_of::<usize>()),
             );
             self.write_memory(current_registers.stack_pointer(), usize_arr_to_u8(stack_arguments).as_slice())?;
         };


### PR DESCRIPTION
- Ensure function calling stack is aligned to 16-byte boundary ([reference](https://en.wikipedia.org/wiki/X86_calling_conventions#Variations:~:text=In%20Linux%2C%20GCC%20sets%20the%20de%20facto%20standard%20for%20calling%20conventions.%20Since%20GCC%20version%204.5%2C%20the%20stack%20must%20be%20aligned%20to%20a%2016%2Dbyte%20boundary%20when%20calling%20a%20function%20(previous%20versions%20only%20required%20a%204%2Dbyte%20alignment).%5B1%5D%5B3%5D))
- Fix wrong conversion from usize arr to u8 arr